### PR TITLE
Revert breaking change in View component to allow View inside Text

### DIFF
--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -39,8 +39,8 @@ if (__DEV__) {
         <TextAncestor.Consumer>
           {hasTextAncestor => {
             invariant(
-              !hasTextAncestor,
-              'Nesting of <View> within <Text> is not currently supported.',
+              !hasTextAncestor || Platform.OS !== 'android',
+              'Nesting of <View> within <Text> is not supported on Android.',
             );
             return <ViewNativeComponent {...props} ref={forwardedRef} />;
           }}

--- a/RNTester/js/TextInputExample.ios.js
+++ b/RNTester/js/TextInputExample.ios.js
@@ -933,6 +933,14 @@ exports.examples = [
             style={styles.multiline}
             dataDetectorTypes="phoneNumber"
           />
+          <TextInput
+            placeholder="multiline with children"
+            multiline={true}
+            enablesReturnKeyAutomatically={true}
+            returnKeyType="go"
+            style={styles.multiline}>
+            <View style={styles.multilineChild} />
+          </TextInput>
         </View>
       );
     },


### PR DESCRIPTION
### Revert breaking change in View component to allow View inside Text again in iOS

## Summary

Views inside Texts were allowed in iOS but this was removed until support for this was done for Android.

## Changelog

- Reverted change that didn't allow Views inside Texts in iOS
